### PR TITLE
add functionalities to automatically discard completed points

### DIFF
--- a/cheat-library/res/map_enkanomiya.json
+++ b/cheat-library/res/map_enkanomiya.json
@@ -9151,5 +9151,31 @@
         424
       ]
     }
+  ],
+  "regenerates": [
+    {
+      "hours": 12,
+      "categories": [ "Animals", "Materials", "Enemies (Common)" ],
+      "exclude": [ "61", "62", "63" ],
+      "include": []
+    },
+    {
+      "hours": 24,
+      "categories": [ "Enemies (Elite)", "Investigation" ],
+      "exclude": [],
+      "include": [ "172" ]
+    },
+    {
+      "hours": 48,
+      "categories": [ "Local Specialties" ],
+      "exclude": [],
+      "include": [ "61", "62", "63", "15", "139" ]
+    },
+    {
+      "hours": 72,
+      "categories": [ "Fishing" ],
+      "exclude": [],
+      "include": [ "16", "80", "202" ]
+    }
   ]
 }

--- a/cheat-library/res/map_golden_apple_archipelago.json
+++ b/cheat-library/res/map_golden_apple_archipelago.json
@@ -2047,5 +2047,31 @@
         351
       ]
     }
+  ],
+  "regenerates": [
+    {
+      "hours": 12,
+      "categories": [ "Animals", "Materials", "Enemies (Common)" ],
+      "exclude": [ "61", "62", "63" ],
+      "include": []
+    },
+    {
+      "hours": 24,
+      "categories": [ "Enemies (Elite)", "Investigation" ],
+      "exclude": [],
+      "include": [ "172" ]
+    },
+    {
+      "hours": 48,
+      "categories": [ "Local Specialties" ],
+      "exclude": [],
+      "include": [ "61", "62", "63", "15", "139" ]
+    },
+    {
+      "hours": 72,
+      "categories": [ "Fishing" ],
+      "exclude": [],
+      "include": [ "16", "80", "202" ]
+    }
   ]
 }

--- a/cheat-library/res/map_teyvat.json
+++ b/cheat-library/res/map_teyvat.json
@@ -135764,5 +135764,31 @@
         424
       ]
     }
+  ],
+  "regenerates": [
+    {
+      "hours": 12,
+      "categories": [ "Animals", "Materials", "Enemies (Common)" ],
+      "exclude": [ "61", "62", "63" ],
+      "include": []
+    },
+    {
+      "hours": 24,
+      "categories": [ "Enemies (Elite)", "Investigation" ],
+      "exclude": [],
+      "include": [ "172" ]
+    },
+    {
+      "hours": 48,
+      "categories": [ "Local Specialties" ],
+      "exclude": [],
+      "include": [ "61", "62", "63", "15", "139" ]
+    },
+    {
+      "hours": 72,
+      "categories": [ "Fishing" ],
+      "exclude": [],
+      "include": [ "16", "80", "202" ]
+    }
   ]
 }

--- a/cheat-library/res/map_undeground_mines.json
+++ b/cheat-library/res/map_undeground_mines.json
@@ -5896,5 +5896,31 @@
         424
       ]
     }
+  ],
+  "regenerates": [
+    {
+      "hours": 12,
+      "categories": [ "Animals", "Materials", "Enemies (Common)" ],
+      "exclude": [ "61", "62", "63" ],
+      "include": []
+    },
+    {
+      "hours": 24,
+      "categories": [ "Enemies (Elite)", "Investigation" ],
+      "exclude": [],
+      "include": [ "172" ]
+    },
+    {
+      "hours": 48,
+      "categories": [ "Local Specialties" ],
+      "exclude": [],
+      "include": [ "61", "62", "63", "15", "139" ]
+    },
+    {
+      "hours": 72,
+      "categories": [ "Fishing" ],
+      "exclude": [],
+      "include": [ "16", "80", "202" ]
+    }
   ]
 }

--- a/cheat-library/src/user/cheat/imap/InteractiveMap.cpp
+++ b/cheat-library/src/user/cheat/imap/InteractiveMap.cpp
@@ -1407,7 +1407,7 @@ namespace cheat::feature
 
 					for (auto& childLable : categoryChildren)
 					{
-						if (regenerateExclude.find(childLable->id) == regenerateExclude.end())
+						if (!regenerateExclude.contains(std::to_string(childLable->id)))
 						{
 							regenerateTime[childLable->id] = regenerateTimeInMS;
 						}

--- a/cheat-library/src/user/cheat/imap/InteractiveMap.h
+++ b/cheat-library/src/user/cheat/imap/InteractiveMap.h
@@ -133,6 +133,7 @@ namespace cheat::feature
 			std::map<uint32_t, LabelData> labels;
 			std::map<std::string, LabelData*> nameToLabel;
 			std::vector<CategoryData> categories;
+			std::map<uint32_t, int64_t> regenerateTime;
 		};
 
 		struct MaterialData
@@ -183,6 +184,7 @@ namespace cheat::feature
 		void LoadLabelData(const nlohmann::json& data, uint32_t sceneID, uint32_t labelID);
 		void LoadCategoriaData(const nlohmann::json& data, uint32_t sceneID);
 		void LoadSceneData(const nlohmann::json& data, uint32_t sceneID);
+		void LoadRegenrateTimeData(const nlohmann::json& data, uint32_t sceneID);
 		void LoadScenesData();
 
 		// Parsing ascension materials data


### PR DESCRIPTION
The purpose of this pull request is to add functionalities to interactive map, so that when loading completed points from user cfg, points with resources already regenerated will be ignored. This improves the user's experience so that there is no need to reset all completed points every time.

The source of regeneration time is wikipedia, therefore the current data may not be accurate. Investigation points may have different regenerate time based on their yields, so it may be better to just ignore them.

This pull request is based on older version of the code, but there should be no conflict.

An alternative approach other than modifying all the map files is to add another file specifying global labels and categories, as categories and label ids are shared across all scenes.

i would like to hear feedback from you, as I am not familiar with C++ and my code could be problematic. Thank you for your hard work!